### PR TITLE
Fix default TCP port number

### DIFF
--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -57,7 +57,7 @@ function TCPStream(opts) {
         SyslogStream.call(this, opts);
 
         this.host = opts.host || '127.0.0.1';
-        this.port = opts.port || 10514;
+        this.port = opts.port || 514;
 
         this.queue = [];
 


### PR DESCRIPTION
According to http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers the TCP port should be 514, not 10514.
