### PR TITLE
Add option to unref TCP socket and reconnect timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ log.debug({foo: 'bar'}, 'hello %s', 'world');
 That's pretty much it.  You create a syslog stream, and point it at a syslog
 server (UDP by default; you can force TCP by setting `type: tcp` in the
 constructor); default is to use facility `user` and a syslog server on
-`127.0.0.1:514`.  Note you *must* pass `type: 'raw'` to bunyan in the top-level
+`127.0.0.1:514`. When using TCP and Node 0.10 or above, you can unref the socket
+by setting `unref: true` in the constructor.
+
+Note you *must* pass `type: 'raw'` to bunyan in the top-level
 stream object or this won't work.
 
 ## Mappings

--- a/lib/tcp.js
+++ b/lib/tcp.js
@@ -82,8 +82,19 @@ function TCPStream(opts) {
                         port: self.port,
                         proxy: self
                 });
-                self.socket.on('close', setTimeout.bind(null, connect, 1000));
-                self.socket.on('error', setTimeout.bind(null, connect, 1000));
+
+                if (opts.unref && self.socket.unref) {
+                        self.socket.unref();
+                }
+
+                function attemptReconnect() {
+                        var handle = setTimeout(connect, 1000);
+                        if (opts.unref && handle.unref) {
+                                handle.unref();
+                        }
+                }
+                self.socket.on('close', attemptReconnect);
+                self.socket.on('error', attemptReconnect);
                 self.socket.once('connect', function () {
                         self.queue.forEach(function (buf) {
                                 self.socket.write(buf);


### PR DESCRIPTION
Calling `unref()` on the socket and timers allows the process to exit without having to close the stream.

(Note that due to https://github.com/mcavage/node-bunyan-syslog/issues/7 closing the stream doesn't actually help).
