### PR TITLE
Implement an optional "simple" format

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ This module maps bunyan levels to syslog levels as follows:
 +--------+--------+
 ```
 
+## Format
+
+The output format can be set through the `format` option in the constructor. Available levels are:
+
+- "json": Default. Log entries are sent as JSON.
+- "simple": Only the `message` is logged as string.
+
 # License
 
 MIT.

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -100,12 +100,14 @@ function SyslogStream(opts) {
         assert.object(opts, 'options');
         assert.optionalNumber(opts.facility, 'options.facility');
         assert.optionalString(opts.name, 'options.name');
+        assert.optionalString(opts.format, 'options.format');
 
         Stream.call(this);
 
         this.facility = opts.facility || 1;
         this.name = opts.name || process.title || process.argv[0];
         this.writable = true;
+        this.format = opts.format || 'json';
 
         if (this.constructor.name === 'SyslogStream') {
                 binding.openlog(this.name, binding.LOG_CONS, 0);
@@ -152,8 +154,8 @@ SyslogStream.prototype.write = function write(r) {
         } else if (typeof (r) === 'object') {
                 h = r.hostname;
                 l = level(r.level);
-                m = JSON.stringify(r, bunyan.safeCycles());
                 t = time(r.time);
+                m = formatRecord(r, this.format);
         } else if (typeof (r) === 'string') {
                 m = r;
         } else {
@@ -190,3 +192,19 @@ SyslogStream.prototype.toString = function toString() {
 
         return (str);
 };
+
+
+function formatRecord(rec, format) {
+    var skip = ['hostname', 'level', 'msg', 'name', 'pid', 'time', 'v'];
+
+    switch (format) {
+        case 'simple':
+            return rec.msg;
+
+        case 'json':
+            /* jsl:fall-thru */
+
+        default:
+            return JSON.stringify(rec, bunyan.safeCycles());
+    }
+}


### PR DESCRIPTION
This PR implements a `format` parameter that lets the user decide which format is being used. The default is `json`, so it works just like before.

The new `simple` format only logs the log message, like the "-o simple" parameter in the Bunyan CLI.

Fixes #14.