### PR TITLE
Introduce a mapping from bunyan levels to syslog levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,59 @@ stream object or this won't work.
 
 ## Mappings
 
-This module maps bunyan levels to syslog levels as follows:
+By default, this module maps bunyan levels to syslog levels as follows:
 
 ```
-+--------+--------+
-| Bunyan | Syslog |
-+--------+--------+
-| fatal  | emerg  |
-+--------+--------+
-| error  | error  |
-+--------+--------+
-| warn   | warn   |
-+--------+--------+
-| info   | info   |
-+--------+--------+
-| *      | debug  |
-+--------+--------+
++--------------+-------------+--------+
+| Bunyan Level | Bunyan Name | Syslog |
++--------------+-------------+--------+
+| 60           | fatal       | emerg  |
++--------------+-------------+--------+
+| 50           | error       | error  |
++--------------+-------------+--------+
+| 40           | warn        | warn   |
++--------------+-------------+--------+
+| 30           | info        | info   |
++--------------+-------------+--------+
+| *            | *           | debug  |
++--------------+-------------+--------+
 ```
+
+.. any levels other than those explicitly defined get mapped to debug.
+ 
+If you need support for other levels, you can pass a mapping to 
+createBunyanStream. You'll need to specify all the levels you care
+about; anything not explicitly defined will get mapped to debug, per usual:
+
+```javascript
+var bunyan = require('bunyan');
+var bsyslog = require('bunyan-syslog');
+
+var log = bunyan.createLogger({
+	name: 'foo',
+	streams: [ {
+		level: 'debug',
+		type: 'raw',
+		stream: bsyslog.createBunyanStream({
+			type: 'sys',
+			facility: bsyslog.local0,
+			host: '192.168.0.1',
+			port: 514,
+			mapping: {
+				60: 'emergency',
+				50: 'error',
+				40: 'warning',
+				35: 'notice',
+				30: 'info'
+			}
+		})
+	}]
+});
+
+log.debug({foo: 'bar'}, 'hello %s', 'world');
+```
+
+
 
 # License
 

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -46,45 +46,30 @@ var bunyan = {
 
 
 // Syslog Levels
-var LOG_EMERG = 0;
-var LOG_ALERT = 1;
-var LOG_CRIT = 2;
-var LOG_ERR = 3;
-var LOG_WARNING = 4;
-var LOG_NOTICE = 5;
-var LOG_INFO = 6;
-var LOG_DEBUG = 7;
+var SYSLOG_LEVEL = {
+        EMERGENCY: 0,
+        ALERT: 1,
+        CRITICAL: 2,
+        ERROR: 3,
+        WARNING: 4,
+        NOTICE: 5,
+        INFO: 6,
+        DEBUG: 7
+};
+
+
+var DEFAULT_MAPPING = {};
+DEFAULT_MAPPING[bunyan.FATAL] = SYSLOG_LEVEL.EMERGENCY;
+DEFAULT_MAPPING[bunyan.ERROR] = SYSLOG_LEVEL.ERROR;
+DEFAULT_MAPPING[bunyan.WARN] = SYSLOG_LEVEL.WARNING;
+DEFAULT_MAPPING[bunyan.INFO] = SYSLOG_LEVEL.INFO;
 
 
 ///--- Helpers
 
-// Translates a Bunyan level into a syslog level
-function level(l) {
-        var sysl;
-
-        switch (l) {
-        case bunyan.FATAL:
-                sysl = LOG_EMERG;
-                break;
-
-        case bunyan.ERROR:
-                sysl = LOG_ERR;
-                break;
-
-        case bunyan.WARN:
-                sysl = LOG_WARNING;
-                break;
-
-        case bunyan.INFO:
-                sysl = LOG_INFO;
-                break;
-
-        default:
-                sysl = LOG_DEBUG;
-                break;
-        }
-
-        return (sysl);
+// Translates a Bunyan level into a syslog level, given a mapping
+function level(mapping, l) {
+        return mapping[l] || SYSLOG_LEVEL.DEBUG;
 }
 
 
@@ -93,6 +78,33 @@ function time(t) {
 }
 
 
+function normalize_mapping(mappings) {
+        var new_mapping = {};
+        var keys = Object.keys(mappings);
+        keys.forEach(function(key) {
+                // positive integer keys or nothin'
+                if (Math.abs(parseInt(key, 10)) != key) {
+                        return;
+                }
+
+                // known syslog levels only
+                var val = mappings[key];
+                if (parseInt(val, 10) === val) {
+                        if (val < 0 || val > 7) {
+                                return;
+                        }
+
+                        new_mapping[key] = val;
+                } else {
+                        val = val.toString().toUpperCase();
+                        if (!SYSLOG_LEVEL[val]) {
+                                return;
+                        }
+                        new_mapping[key] = SYSLOG_LEVEL[val];
+                }
+        });
+        return new_mapping;
+}
 
 ///--- API
 
@@ -100,9 +112,11 @@ function SyslogStream(opts) {
         assert.object(opts, 'options');
         assert.optionalNumber(opts.facility, 'options.facility');
         assert.optionalString(opts.name, 'options.name');
+        assert.optionalObject(opts.mapping, 'options.mapping');
 
         Stream.call(this);
 
+        this.mapping = normalize_mapping(opts.mapping || DEFAULT_MAPPING);
         this.facility = opts.facility || 1;
         this.name = opts.name || process.title || process.argv[0];
         this.writable = true;
@@ -151,7 +165,7 @@ SyslogStream.prototype.write = function write(r) {
                 m = r.toString('utf8');
         } else if (typeof (r) === 'object') {
                 h = r.hostname;
-                l = level(r.level);
+                l = level(this.mapping, r.level);
                 m = JSON.stringify(r, bunyan.safeCycles());
                 t = time(r.time);
         } else if (typeof (r) === 'string') {
@@ -160,7 +174,7 @@ SyslogStream.prototype.write = function write(r) {
                 throw new TypeError('record (Object) required');
         }
 
-        l = (this.facility * 8) + (l !== undefined ? l : level(bunyan.INFO));
+        l = (this.facility * 8) + (l !== undefined ? l : level(this.mapping, bunyan.INFO));
         var hdr = sprintf('<%d>%s %s %s[%d]:',
                           l,
                           (t || time()),


### PR DESCRIPTION
The actual code is generic, though it's impossible to trigger it for new levels (any predefined levels will work) without some changes to bunyan. The test code necessarily depends on a version of bunyan that allows new levels to be created, see https://github.com/trentm/node-bunyan/pull/300.

I'm not expecting this to be merged at the moment -- without the upstream bunyan PR, it doesn't make a lot of sense -- but I needed this functionality now, so I'm putting it out there for a review.  If bunyanmerges my PR, what would need to change here to get this merged?

Thanks. 
