### PR TITLE
Revert engines limit and add license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015 Mark Cavage
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "test": "tap test"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Syslog Stream for Bunyan",
   "version": "0.3.0",
   "author": "Mark Cavage",
+  "license": "MIT",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
While the `engines` field appears to be largely advisory, there does not appear to be a reason to crank it all the way up to v4.0.0.  The module still functions for the v0.10.x series.