### PR TITLE
adding process id, and facility when using syslog system call

### DIFF
--- a/lib/sys.js
+++ b/lib/sys.js
@@ -108,7 +108,7 @@ function SyslogStream(opts) {
         this.writable = true;
 
         if (this.constructor.name === 'SyslogStream') {
-                binding.openlog(this.name, binding.LOG_CONS, 0);
+                binding.openlog(this.name, binding.LOG_CONS | binding.LOG_PID | binding.LOG_NDELAY, this.facility * 8);
                 process.nextTick(this.emit.bind(this, 'connect'));
         }
 }
@@ -160,15 +160,15 @@ SyslogStream.prototype.write = function write(r) {
                 throw new TypeError('record (Object) required');
         }
 
-        l = (this.facility * 8) + (l !== undefined ? l : level(bunyan.INFO));
-        var hdr = sprintf('<%d>%s %s %s[%d]:',
-                          l,
-                          (t || time()),
-                          (h || HOSTNAME),
-                          this.name,
-                          process.pid);
 
         if (this._send) {
+                l = (this.facility * 8) + (l !== undefined ? l : level(bunyan.INFO));
+                var hdr = sprintf('<%d>%s %s %s[%d]:',
+                                  l,
+                                  (t || time()),
+                                  (h || HOSTNAME),
+                                  this.name,
+                                  process.pid);
                 this._send(hdr + m);
         } else {
                 binding.syslog(l, m);


### PR DESCRIPTION
This PR adds PID and facility when using the syslog system call.  I also added the `LOG_NDELAY` option to open the connection to the logger right away, and not wait for the first message.